### PR TITLE
QuickScale mode + bugfix

### DIFF
--- a/InstrumentComponent.py
+++ b/InstrumentComponent.py
@@ -304,12 +304,14 @@ class CommonModeComponent(ControlSurfaceComponent):
 	
 	@scale_button.pressed
 	def enter_scale(self, button):
+		self._instrument_component._scale_component.set_enabled(True)
 		self._previous_mode = self._instrument_component.get_mode()
 		self._previous_scale_mode = self._instrument_component._scale_component._is_drumrack
 		self._instrument_component.set_mode("scale_mode")
 		
 	@scale_button.released
 	def leave_scale(self, button):
+		self._instrument_component._scale_component.set_enabled(False)
 		if self._previous_scale_mode != self._instrument_component._scale_component._is_drumrack:
 			if self._instrument_component._scale_component._is_drumrack:
 				self._instrument_component.set_mode("drum_mode")

--- a/ScaleComponent.py
+++ b/ScaleComponent.py
@@ -395,7 +395,10 @@ class ScaleComponent(ControlSurfaceComponent):
 
 			if y == 1 and x == 7 and not self.is_drumrack:
 				self._quick_scale = not self._quick_scale
-				self._control_surface.show_message("Quick scale")
+				if self._quick_scale:
+					self._control_surface.show_message("Quick scale : ON")
+				else:
+					self._control_surface.show_message("Quick scale : OFF")
 			# octave
 			if y == 3:
 				self._octave = x

--- a/ScaleComponent.py
+++ b/ScaleComponent.py
@@ -452,6 +452,8 @@ class ScaleComponent(ControlSurfaceComponent):
 			for n in xrange(12):
 				if self._quick_keys[n]:
 					notes.append(n)
+			if len(notes) == 0:
+				notes = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]
 		else:
 			notes = self.notes
 

--- a/ScaleComponent.py
+++ b/ScaleComponent.py
@@ -563,8 +563,11 @@ class MelodicPattern(object):
 	def note(self, x, y):
 		octave, note = self._octave_and_note(x, y)
 		index = self.base_note + 12 * octave + note 
-	 	root = note == self.scale[0]
-		highlight =  note == self.scale[2] or note == self.scale[4]
+		root = note == self.scale[0]
+		if len(self.scale) < 5:
+			highlight = False
+		else:
+			highlight =  note == self.scale[2] or note == self.scale[4]
 		in_scale = note in self.scale
 		valid = index in self.valid_notes
 		return self.NoteInfo(

--- a/ScaleComponent.py
+++ b/ScaleComponent.py
@@ -55,6 +55,7 @@ class ScaleComponent(ControlSurfaceComponent):
 		self._mode = mode #chromatic, diatonic
 		self._is_drumrack = False
 		self._quick_scale = False
+		self._quick_keys = [True, True, True, True, True, True, True, True, True, True, True, True]
 		self._is_horizontal = True
 		self._is_absolute = False
 		self._interval = 3
@@ -203,10 +204,16 @@ class ScaleComponent(ControlSurfaceComponent):
 						button.set_light("DefaultButton.Disabled")
 					else:
 						if col==0 or col==1 or col==3 or col==4 or col==5:
-							if self._key == self._white_notes_index[col]+1:
-								button.set_light("Scale.Key.On")
+							if self._quick_scale:
+								if self._quick_keys[self._white_notes_index[col]+1]:
+									button.set_light("Scale.Key.On")
+								else:
+									button.set_light("Scale.Key.Off")
 							else:
-								 button.set_light("Scale.Key.Off")
+								if self._key == self._white_notes_index[col]+1:
+									button.set_light("Scale.Key.On")
+								else:
+									button.set_light("Scale.Key.Off")
 						elif col==2:
 							button.set_light("Scale.RelativeScale")
 						elif col==6:
@@ -221,10 +228,16 @@ class ScaleComponent(ControlSurfaceComponent):
 						button.set_light("DefaultButton.Disabled")
 					else:
 						if col<7:
-							if self._key == self._white_notes_index[col]:
-								button.set_light("Scale.Key.On")
+							if self._quick_scale:
+								if self._quick_keys[self._white_notes_index[col]]:
+									button.set_light("Scale.Key.On")
+								else:
+									button.set_light("Scale.Key.Off")
 							else:
-								 button.set_light("Scale.Key.Off")
+								if self._key == self._white_notes_index[col]:
+									button.set_light("Scale.Key.On")
+								else:
+									button.set_light("Scale.Key.Off")
 						else:
 							button.set_light("Scale.CircleOfFifths")
 				elif row==3:
@@ -327,10 +340,16 @@ class ScaleComponent(ControlSurfaceComponent):
 				selected_key = self._key
 				selected_modus = self._modus
 				if y == 1 and x in[0, 1, 3, 4, 5] or y == 2 and x < 7:
-					root = [0, 2, 4, 5, 7, 9, 11, 12][x]
-					if y == 1:
-						root = root + 1
-					self._control_surface.show_message("root "+keys[root])
+					if self._quick_scale:
+						key = [0, 2, 4, 5, 7, 9, 11, 12][x]
+						if y == 1:
+							key = key + 1
+						self._quick_keys[key] = not self._quick_keys[key]
+					else:
+						root = [0, 2, 4, 5, 7, 9, 11, 12][x]
+						if y == 1:
+							root = root + 1
+						self._control_surface.show_message("root "+keys[root])
 
 				# if root == selected_key:#alternate minor/major
 				# 	if selected_modus==0:
@@ -419,7 +438,14 @@ class ScaleComponent(ControlSurfaceComponent):
 	
 	
 	def get_pattern(self):
-		notes = self.notes
+		if self._quick_scale:
+			notes = []
+			for n in xrange(12):
+				if self._quick_keys[n]:
+					notes.append(n)
+		else:
+			notes = self.notes
+
 		# origin
 		if not self._is_absolute:
 			origin = 0

--- a/ScaleComponent.py
+++ b/ScaleComponent.py
@@ -217,7 +217,10 @@ class ScaleComponent(ControlSurfaceComponent):
 						elif col==2:
 							button.set_light("Scale.RelativeScale")
 						elif col==6:
-							button.set_light("Scale.CircleOfFifths")
+							if self._quick_scale:
+								button.set_light("DefaultButton.Disabled")
+							else:
+								button.set_light("Scale.CircleOfFifths")
 						elif col==7:
 							if self._quick_scale:
 								button.set_light("Scale.QuickScale.On")
@@ -239,14 +242,17 @@ class ScaleComponent(ControlSurfaceComponent):
 								else:
 									button.set_light("Scale.Key.Off")
 						else:
-							button.set_light("Scale.CircleOfFifths")
+							if self._quick_scale:
+								button.set_light("DefaultButton.Disabled")
+							else:
+								button.set_light("Scale.CircleOfFifths")
 				elif row==3:
 					if self._octave == col:
 						button.set_light("Scale.Octave.On")
 					else:
 						button.set_light("Scale.Octave.Off")
 				elif row==4:
-					if self.is_drumrack:
+					if self.is_drumrack or self._quick_scale:
 						button.set_light("DefaultButton.Disabled")
 					else:
 						if self._modus == col:
@@ -254,7 +260,7 @@ class ScaleComponent(ControlSurfaceComponent):
 						else:
 							button.set_light("Scale.Modus.Off")
 				elif row==5:
-					if self.is_drumrack:
+					if self.is_drumrack or self._quick_scale:
 						button.set_light("DefaultButton.Disabled")
 					else:
 						if self._modus == col+8:
@@ -262,7 +268,7 @@ class ScaleComponent(ControlSurfaceComponent):
 						else:
 							button.set_light("Scale.Modus.Off")
 				elif row==6:
-					if self.is_drumrack:
+					if self.is_drumrack or self._quick_scale:
 						button.set_light("DefaultButton.Disabled")
 					else:
 						if self._modus == col+16:
@@ -270,7 +276,7 @@ class ScaleComponent(ControlSurfaceComponent):
 						else:
 							button.set_light("Scale.Modus.Off")
 				elif row==7:
-					if self.is_drumrack:
+					if self.is_drumrack or self._quick_scale:
 						button.set_light("DefaultButton.Disabled")
 					else:
 						if col+24>len(self._modus_list):


### PR DESCRIPTION
Test implementation of a quick scale mode 
(see demo https://youtu.be/Sqs5UQ6yLfk )

While busy on the quick scale feature, I stumbled upon a bug where the scale component appeared to stay enabled in background, receiving button presses when it shouldn't (see commit 01902a7
 for my quick fix).

Not sure if that bug was caused by my own changes, but I saw a user reporting this on the Ableton forum thread ( https://forum.ableton.com/viewtopic.php?p=1715300#p1715300 ), and I could reproduce it with the current version of the script.