### PR TITLE
Fix for website not loading JS or CSS

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -3,8 +3,8 @@
 <head>
 	<meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
 	<title>Launchpad Pro95 : Ableton LIVE control surface remote scripts for Novation Launchpad Pro</title>
-	<link rel="stylesheet" type="text/css" media="screen" href="http://motscousus.com/css/site.css" />
-	<script type="text/javascript" src="http://motscousus.com/js/site.js"></script>
+	<link rel="stylesheet" type="text/css" media="screen" href="https://motscousus.com/css/site.css" />
+	<script type="text/javascript" src="https://motscousus.com/js/site.js"></script>
 </head>
 <body>
 


### PR DESCRIPTION
The Launchpad Pro page on the website tries to load its javascript and css styles using http, which most browsers seem to block now if on a site served with https. Hopefully just changing the links to start with "https" instead of "http" should solve it :)