### PR TITLE
[py3] Cast all division results back to int

### DIFF
--- a/NoteEditorComponent.py
+++ b/NoteEditorComponent.py
@@ -128,7 +128,7 @@ class NoteEditorComponent(ControlSurfaceComponent):
 		if self.is_multinote:
 			self._page = page
 		else:
-			self._page = page / 4  # number of line per note ?
+			self._page = int(page / 4)  # number of line per note ?
 
 	def set_clip(self, clip):
 		self._clip = clip
@@ -161,7 +161,7 @@ class NoteEditorComponent(ControlSurfaceComponent):
 			self._grid_back_buffer[self._page % self.width][i] = "StepSequencer.NoteEditor.PageMarker"
 
 	def _display_note_markers(self):
-		for i in range(0, self.height / self.number_of_lines_per_note):
+		for i in range(0, int(self.height / self.number_of_lines_per_note)):
 			if self._key_index_is_root_note[i]:
 				for j in range(0, self.number_of_lines_per_note):
 					self._grid_back_buffer[0][self.height - i * self.number_of_lines_per_note - j - 1] = "StepSequencer.NoteEditor.NoteMarker"
@@ -331,7 +331,7 @@ class NoteEditorComponent(ControlSurfaceComponent):
 
 				if self.is_multinote:
 					time = self.quantization * (self._page * self.width * self.number_of_lines_per_note + x + (y % self.number_of_lines_per_note * self.width))
-					pitch = self._key_indexes[8 / self.number_of_lines_per_note - 1 - y / self.number_of_lines_per_note]
+					pitch = self._key_indexes[int(8 / self.number_of_lines_per_note - 1 - y / self.number_of_lines_per_note)]
 				else:
 					time = self.quantization * (self._page * self.width * self.number_of_lines_per_note + y * self.width + x)
 					pitch = self._key_indexes[0]

--- a/StepSequencerComponent.py
+++ b/StepSequencerComponent.py
@@ -374,11 +374,11 @@ class NoteSelectorComponent(ControlSurfaceComponent):
 
 	def set_selected_note(self, selected_note):
 		if self.is_drumrack:
-			self._root_note = ((selected_note + 12) / 16 - 1) * 16 + 4
+			self._root_note = int((selected_note + 12) / 16 - 1) * 16 + 4
 			self._offset = (selected_note - self._root_note + 16) % 16
 			# self._control_surface.log_message("DR selected_note:"+str(selected_note)+" self._root_note: "+ str(self._root_note)+" offset: "+ str(self._offset))
 		else:
-			self._root_note = ((selected_note - self._key) / 12) * 12 + self._key
+			self._root_note = int((selected_note - self._key) / 12) * 12 + self._key
 			self._offset = (selected_note + 12 - self._root_note) % 12
 			# self._control_surface.log_message("CHR selected_note:"+str(selected_note)+" self._root_note: "+ str(self._root_note)+" offset: "+ str(self._offset))
 
@@ -1357,7 +1357,7 @@ class StepSequencerComponent(CompoundComponent):
 		if (value is not 0):
 			self._mode_backup = self._mode
 			if self._scale_component != None and self._note_selector != None:
-				self._scale_component.set_octave(self._note_selector._root_note / 12)
+				self._scale_component.set_octave(int(self._note_selector._root_note / 12))
 				self._scale_component.set_key(self._note_selector._key)
 				self.set_mode(STEPSEQ_MODE_SCALE_EDIT)
 		else:

--- a/StepSequencerComponent2.py
+++ b/StepSequencerComponent2.py
@@ -221,7 +221,7 @@ class MelodicNoteEditorComponent(ControlSurfaceComponent):
 					if self._notes_pitches[x * 7 + note_index] == 1:
 						time = x * self._quantization
 						velocity = self._velocity_map[self._notes_velocities[x]]
-						length = self._length_map[self._notes_lengths[x]] * self._quantization / 4.0
+						length = self._length_map[self._notes_lengths[x]] * int(self._quantization / 4.0)
 						pitch = self._key_indexes[note_index] + 12 * (self._notes_octaves[x] - 2)
 						if(pitch >= 0 and pitch < 128 and velocity >= 0 and velocity < 128 and length >= 0):
 							note_cache.append([pitch, time, length, velocity, False])


### PR DESCRIPTION
When connecting to Live 11.2.6 with my Launchpad Pro mk1, the sequencer throws errors related to unexpected float types for several of the side buttons (eg. change octave, enter melodic mode).

This commit attempts to find all places where division is used and a floating point number is returned instead of an int (Python 3 changes the default behavior of int division).

I've tested the step sequencer mode and all features seem to work. I'm unable to reproduce any of the errors in the logs now.