### PR TITLE
fix: correct octave offset for pads below lowest root note

### DIFF
--- a/ScaleComponent.py
+++ b/ScaleComponent.py
@@ -577,6 +577,9 @@ class MelodicPattern(object):
 		if self.chromatic_gtr_mode and y > 3:
 			index = index - 1
 		octave = int(index / scale_size)
+		if index < 0:
+			# Lower the octave by 1 if this pad represents a note below the bottom root
+			octave -= 1
 		note = scale[index % scale_size]
 		return (octave, note)
 


### PR DESCRIPTION
Previously, in absolute root mode, pads assigned to notes lower than the bottom-most root note were playing one octave higher than intended.

Tested in:
- Chromatic mode
- Absolute root mode
- Key: B major

In this case, the bottom-left 1st to 6th pads, and the 1st to 3rd pads of the second-bottom row, are mapped to notes below the lowest root note.
